### PR TITLE
feat: Add auto_bump config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY . /tmp/src/
 
 RUN yarn global add --production true "file:/tmp/src" && rm -rf /tmp/src
 
-ENTRYPOINT [ "tag-gh-pubish-action" ]
+ENTRYPOINT [ "tag-gh-publish-action" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY . /tmp/src/
 
 RUN yarn global add --production true "file:/tmp/src" && rm -rf /tmp/src
 
-ENTRYPOINT [ "npm-publish-action" ]
+ENTRYPOINT [ "tag-gh-pubish-action" ]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated        
 ```
 
-Now, when someone changes the version in `package.json` to 1.2.3 and pushes a commit with the message `Release 1.2.3`, the `npm-publish` action will create a new tag `v1.2.3` and publish the package to the npm registry.
+Now, when someone changes the version in `package.json` to 1.2.3 and pushes a commit with the message `Release 1.2.3`, the `tag-release` action will create a new tag `v1.2.3` and publish the package to the npm registry.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: 10.0.0
     - name: Publish if version has been updated
-      uses: tonthanhhung/tag-gh-publish-action@23d0c5d
+      uses: tonthanhhung/tag-gh-publish-action@168e35e
       env: # More info about the environment variables in the README
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated        
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
         tag_message: "v%s"
         commit_pattern: "^Release (\\S+)"
         workspace: "."
+        auto_bump: "true"
       env: # More info about the environment variables in the README
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings
@@ -45,6 +46,7 @@ These inputs are optional: that means that if you don't enter them, default valu
 - `tag_message`: the message pattern of the new tag
 - `commit_pattern`: pattern that the commit message needs to follow
 - `workspace`: custom workspace directory that contains the `package.json` file
+- `auto_bump`: allow automatically version bump
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: 10.0.0
     - name: Publish if version has been updated
-      uses: tonthanhhung/tag-gh-publish-action@f1eb478
+      uses: tonthanhhung/tag-gh-publish-action@3f9df2b
       env: # More info about the environment variables in the README
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated        
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: 10.0.0
     - name: Publish if version has been updated
-      uses: tonthanhhung/tag-gh-publish-action@3f9df2b
+      uses: tonthanhhung/tag-gh-publish-action@23d0c5d
       env: # More info about the environment variables in the README
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated        
 ```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# npm-publish-action
+# tag-gh-publish-action
 
-GitHub action to automatically publish packages to npm.
+GitHub action to automatically publish packages to github tag.
 
 ## Usage
 
-Create a new `.github/workflows/npm-publish.yml` file:
+Create a new `.github/workflows/tag-release.yml` file:
 
 ```yaml
-name: npm-publish
+name: tag-release
 on:
   push:
     branches:
       - master # Change this to your default branch
 jobs:
-  npm-publish:
-    name: npm-publish
+  tag-release:
+    name: tag-release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -24,34 +24,16 @@ jobs:
       with:
         node-version: 10.0.0
     - name: Publish if version has been updated
-      uses: pascalgn/npm-publish-action@06e0830ea83eea10ed4a62654eeaedafb8bf50fc
-      with: # All of theses inputs are optional
-        tag_name: "v%s"
-        tag_message: "v%s"
-        commit_pattern: "^Release (\\S+)"
-        workspace: "."
-        auto_bump: "true"
+      uses: tonthanhhung/tag-gh-publish-action@f1eb478
       env: # More info about the environment variables in the README
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated        
 ```
 
 Now, when someone changes the version in `package.json` to 1.2.3 and pushes a commit with the message `Release 1.2.3`, the `npm-publish` action will create a new tag `v1.2.3` and publish the package to the npm registry.
 
-### Inputs
-
-These inputs are optional: that means that if you don't enter them, default values will be used and it'll work just fine.
-
-- `tag_name`: the name pattern of the new tag
-- `tag_message`: the message pattern of the new tag
-- `commit_pattern`: pattern that the commit message needs to follow
-- `workspace`: custom workspace directory that contains the `package.json` file
-- `auto_bump`: allow automatically version bump
-
 ### Environment variables
 
 - `GITHUB_TOKEN`: this is a token that GitHub generates automatically, you only need to pass it to the action as in the example
-- `NPM_AUTH_TOKEN`: this is the token the action will use to authenticate to [npm](https://npmjs.com). You need to generate one in npm, then you can add it to your secrets (settings -> secrets) so that it can be passed to the action. DO NOT put the token directly in your workflow file.
 
 ## Related projects
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   workspace:
     description: Custom workspace directory that contains the package.json file.
     required: false
+  auto_bump:
+    description: Allow version will be automatically bump via conventional message
+    required: false
 
 runs:
   using: docker

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
+const core = require('@actions/core');
 
 const process = require("process");
-const { join } = require("path");
-const { spawn } = require("child_process");
-const { readFile } = require("fs");
+const {join} = require("path");
+const {spawn} = require("child_process");
+const {readFile} = require("fs");
 
 async function main() {
   const dir =
@@ -18,13 +19,13 @@ async function main() {
   const commitPattern =
     getEnv("COMMIT_PATTERN") || "^(?:Release|Version) (\\S+)";
 
-  const { name, email } = eventObj.repository.owner;
+  const {name, email} = eventObj.repository.owner;
 
   const config = {
     commitPattern,
     tagName: placeholderEnv("TAG_NAME", "v%s"),
     tagMessage: placeholderEnv("TAG_MESSAGE", "v%s"),
-    tagAuthor: { name, email }
+    tagAuthor: {name, email}
   };
 
   await processDirectory(dir, config, eventObj.commits);
@@ -45,7 +46,7 @@ function placeholderEnv(name, defaultValue) {
   }
 }
 
-async function processDirectory(dir, config, commits) {
+async function getVersion(dir) {
   const packageFile = join(dir, "package.json");
   const packageObj = await readJson(packageFile).catch(() =>
     Promise.reject(
@@ -57,26 +58,76 @@ async function processDirectory(dir, config, commits) {
     throw new Error("missing version field!");
   }
 
-  const { version } = packageObj;
+  const {version} = packageObj;
+  return version
+}
 
-  checkCommit(config, commits, version);
+async function processDirectory(dir, config, commits) {
 
-  await createTag(dir, config, version);
-  await publishPackage(dir, config, version);
+  let version = await getVersion(dir)
+  await gitSetup(dir, config)
+
+  await addBuiltPackage(dir);
+  version = await bumpVersion(dir, config, getCommitVersion(config, commits), commits);
+
+  await run(dir, "git", "push", "origin", `refs/tags/v${version}`);
+  await run(dir, "git", "reset", "--soft", "HEAD^")
+  await run(dir, "git", "restore", "--staged", ".")
+  await run(dir, "git", "commit", "-a", "-m", `Release ${version}`).catch(e =>
+    e instanceof ExitError && e.code === 1 ? false : Promise.reject(e)
+  )
+  await run(dir, "git", "push")
 
   console.log("Done.");
 }
 
-function checkCommit(config, commits, version) {
+
+async function bumpVersion(dir, config, version, commits) {
+  const args = version ? ["--new-version", version] : [`--${getStrategyFromCommit(commits)}`]
+
+  await run(
+    dir,
+    "yarn",
+    "version",
+    ...args,
+  ).catch(e =>
+    e instanceof ExitError && e.code === 1 ? false : Promise.reject(e)
+  );
+
+  const newVersion = await getVersion(dir)
+  console.log(`New version: ${newVersion}`)
+  return newVersion;
+}
+
+
+function getCommitVersion(config, commits) {
   for (const commit of commits) {
     const match = commit.message.match(config.commitPattern);
-    if (match && match[1] === version) {
-      console.log(`Found commit: ${commit.message}`);
-      return;
+    if (match && match[1]) {
+      return match[1]
     }
   }
-  throw new NeutralExitError(`No commit found for version: ${version}`);
+  return null
 }
+
+function getStrategyFromCommit(commits) {
+
+  if (commits.some(({message}) =>
+    message.includes("BREAKING CHANGE") ||
+    message.toLowerCase().includes("major")
+  )) {
+    return "major"
+  }
+
+  if (commits.some(({message}) =>
+    message.toLowerCase().startsWith("feat") ||
+    message.toLowerCase().includes("minor")
+  )) {
+    return "minor"
+  }
+  return "patch"
+}
+
 
 async function readJson(file) {
   const data = await new Promise((resolve, reject) =>
@@ -89,6 +140,12 @@ async function readJson(file) {
     })
   );
   return JSON.parse(data);
+}
+
+async function gitSetup(dir, config) {
+  const {name, email} = config.tagAuthor;
+  await run(dir, "git", "config", "user.name", name);
+  await run(dir, "git", "config", "user.email", email);
 }
 
 async function createTag(dir, config, version) {
@@ -111,27 +168,16 @@ async function createTag(dir, config, version) {
     throw new NeutralExitError();
   }
 
-  const { name, email } = config.tagAuthor;
-  await run(dir, "git", "config", "user.name", name);
-  await run(dir, "git", "config", "user.email", email);
-
   await run(dir, "git", "tag", "-a", "-m", tagMessage, tagName);
   await run(dir, "git", "push", "origin", `refs/tags/${tagName}`);
 
   console.log("Tag has been created successfully:", tagName);
 }
 
-async function publishPackage(dir, config, version) {
-  await run(
-    dir,
-    "yarn",
-    "publish",
-    "--non-interactive",
-    "--new-version",
-    version
-  );
-
-  console.log("Version has been published successfully:", version);
+async function addBuiltPackage(dir) {
+  await run(dir, "yarn");
+  await run(dir, "yarn", "build");
+  await run(dir, "git", "add", "-f", "dist")
 }
 
 function run(cwd, command, ...args) {
@@ -168,7 +214,8 @@ class ExitError extends Error {
   }
 }
 
-class NeutralExitError extends Error {}
+class NeutralExitError extends Error {
+}
 
 if (require.main === module) {
   main().catch(e => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-publish-action",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "GitHub action to automatically publish packages to npm",
   "author": "Pascal",
   "license": "MIT",
@@ -10,6 +10,9 @@
   },
   "scripts": {
     "lint": "eslint ."
+  },
+  "dependencies": {
+    "@actions/core": "^1.1.1"
   },
   "devDependencies": {
     "eslint": "^7.5.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "npm-publish-action",
+  "name": "tag-gh-publish-action",
   "version": "0.0.2",
-  "description": "GitHub action to automatically publish packages to npm",
+  "description": "GitHub action to automatically publish packages to github repo tag",
   "author": "Pascal",
+  "contributors": [
+    "tonthanhhung"
+  ],
   "license": "MIT",
   "private": true,
   "bin": {
-    "npm-publish-action": "./index.js"
+    "tag-gh-publish-action": "./index.js"
   },
   "scripts": {
     "lint": "eslint ."

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.1.1":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.4.tgz#96179dbf9f8d951dd74b40a0dbd5c22555d186ab"
+  integrity sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg==
+
 "@babel/code-frame@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"


### PR DESCRIPTION
Add `auto_bump`, it's an optional config to let the action automatically increase version with conventional message.
Based on the commit messages, increment the version from the -latest release.
- If the string "BREAKING CHANGE" or "major" is found anywhere in any of the commit messages or descriptions the major version will be incremented.
- If a commit message begins with the string "feat" or includes "minor" then the minor version will be increased. This works for most common commit metadata for feature additions: "feat: new API" and "feature: new API".
- All other changes will increment the patch version.

Push the bumped npm version in package.json back into the repo.