### PR TITLE
Fixed workspace not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { readFile } = require("fs");
 
 async function main() {
   const dir =
-    process.env.WORKSPACE ||
+    getEnv("WORKSPACE") ||
     process.env.GITHUB_WORKSPACE ||
     "/github/workspace";
 


### PR DESCRIPTION
Fix #18 
workspace does not work every time it is using the default path GITHUB_WORKSPACE, so I fixed it.
Please merge this or fix the problem ASAP.