### PR TITLE
Add support for disabling git tag creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
       with: # All of theses inputs are optional
         tag_name: "v%s"
         tag_message: "v%s"
+        create_tag: "true"
         commit_pattern: "^Release (\\S+)"
         workspace: "."
         publish_command: "yarn"
@@ -41,6 +42,7 @@ These inputs are optional: that means that if you don't enter them, default valu
 
 - `tag_name`: the name pattern of the new tag
 - `tag_message`: the message pattern of the new tag
+- `create_tag`: whether to create a git tag or not (defaults to `"true"`)
 - `commit_pattern`: pattern that the commit message needs to follow
 - `workspace`: custom workspace directory that contains the `package.json` file
 - `publish_command`: custom publish command (defaults to `yarn`)

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ async function main() {
   const commitPattern =
     getEnv("COMMIT_PATTERN") || "^(?:Release|Version) (\\S+)";
 
+  const createTagFlag = getEnv("CREATE_TAG") !== "false";
+  
   const publishCommand = getEnv("PUBLISH_COMMAND") || "yarn";
   const publishArgs = arrayEnv("PUBLISH_ARGS");
 
@@ -23,6 +25,7 @@ async function main() {
 
   const config = {
     commitPattern,
+    createTag: createTagFlag,
     tagName: placeholderEnv("TAG_NAME", "v%s"),
     tagMessage: placeholderEnv("TAG_MESSAGE", "v%s"),
     tagAuthor: { name, email },
@@ -69,7 +72,10 @@ async function processDirectory(dir, config, commits) {
 
   checkCommit(config, commits, version);
 
-  await createTag(dir, config, version);
+  if (config.createTag) {
+    await createTag(dir, config, version);  
+  }
+  
   await publishPackage(dir, config, version);
 
   console.log("Done.");


### PR DESCRIPTION
Allows the disabling of GIT tag creation.

Useful for monorepos where you only want one of your actions to attempt to create a tag (as subsequent actions will bail-out if they detect the tag already exists, and will result in the `npm publish` step being skipped).