### PR TITLE
Add context output after run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: Publish command arguments.
     required: false
 
+outputs:
+  changed:
+    description: Whether the version has changed in the examined commits
+  version:
+    description: The detected version number
+  commit:
+    description: The SHA of the commit where the version change has been detected
+
 runs:
   using: docker
   image: Dockerfile

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const process = require("process");
-const os = require("os");
 const { join } = require("path");
 const { spawn } = require("child_process");
 const { readFile } = require("fs");
@@ -79,9 +78,10 @@ async function processDirectory(dir, config, commits) {
 
   await publishPackage(dir, config, version);
 
-  setOutput('changed', true)
-  setOutput('version', version)
-  setOutput('commit', foundCommit.id)
+  setOutput("changed", "true");
+  setOutput("version", version);
+  setOutput("commit", foundCommit.sha);
+
   console.log("Done.");
 }
 
@@ -154,25 +154,9 @@ async function publishPackage(dir, config, version) {
   console.log("Version has been published successfully:", version);
 }
 
-function setOutput(name, value = '') {
-  if (typeof name !== "string") name = JSON.stringify(name);
-  if (typeof value !== "string") value = JSON.stringify(value);
-  
-  const cmd = `::set-output name=${escapeProperty(name)}::${escapeData(value)}`;
-  process.stdout.write(cmd + os.EOL);
-}
-
-function escapeProperty(s) {
-  return s
-    .replace(/%/g, "%25")
-    .replace(/\r/g, "%0D")
-    .replace(/\n/g, "%0A")
-    .replace(/:/g, "%3A")
-    .replace(/,/g, "%2C");
-}
-
-function escapeData(s) {
-  return s.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+function setOutput(name, value = "") {
+  const out = `name=${encodeURIComponent(name)}::${encodeURIComponent(value)}`;
+  console.log(`::set-output ${out}`);
 }
 
 function run(cwd, command, ...args) {
@@ -213,7 +197,7 @@ class NeutralExitError extends Error {}
 
 if (require.main === module) {
   main().catch(e => {
-    setOutput('changed', false)
+    setOutput("changed", false);
     if (e instanceof NeutralExitError) {
       // GitHub removed support for neutral exit code:
       // https://twitter.com/ethomson/status/1163899559279497217

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const process = require("process");
+const os = require("os");
 const { join } = require("path");
 const { spawn } = require("child_process");
 const { readFile } = require("fs");
@@ -17,7 +18,7 @@ async function main() {
     getEnv("COMMIT_PATTERN") || "^(?:Release|Version) (\\S+)";
 
   const createTagFlag = getEnv("CREATE_TAG") !== "false";
-  
+
   const publishCommand = getEnv("PUBLISH_COMMAND") || "yarn";
   const publishArgs = arrayEnv("PUBLISH_ARGS");
 
@@ -70,14 +71,17 @@ async function processDirectory(dir, config, commits) {
 
   const { version } = packageObj;
 
-  checkCommit(config, commits, version);
+  const foundCommit = checkCommit(config, commits, version);
 
   if (config.createTag) {
-    await createTag(dir, config, version);  
+    await createTag(dir, config, version);
   }
-  
+
   await publishPackage(dir, config, version);
 
+  setOutput('changed', true)
+  setOutput('version', version)
+  setOutput('commit', foundCommit.id)
   console.log("Done.");
 }
 
@@ -86,7 +90,7 @@ function checkCommit(config, commits, version) {
     const match = commit.message.match(config.commitPattern);
     if (match && match[1] === version) {
       console.log(`Found commit: ${commit.message}`);
-      return;
+      return commit;
     }
   }
   throw new NeutralExitError(`No commit found for version: ${version}`);
@@ -150,6 +154,27 @@ async function publishPackage(dir, config, version) {
   console.log("Version has been published successfully:", version);
 }
 
+function setOutput(name, value = '') {
+  if (typeof name !== "string") name = JSON.stringify(name);
+  if (typeof value !== "string") value = JSON.stringify(value);
+  
+  const cmd = `::set-output name=${escapeProperty(name)}::${escapeData(value)}`;
+  process.stdout.write(cmd + os.EOL);
+}
+
+function escapeProperty(s) {
+  return s
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+}
+
+function escapeData(s) {
+  return s.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
 function run(cwd, command, ...args) {
   console.log("Executing:", command, args.join(" "));
   return new Promise((resolve, reject) => {
@@ -188,6 +213,7 @@ class NeutralExitError extends Error {}
 
 if (require.main === module) {
   main().catch(e => {
+    setOutput('changed', false)
     if (e instanceof NeutralExitError) {
       // GitHub removed support for neutral exit code:
       // https://twitter.com/ethomson/status/1163899559279497217

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-publish-action",
-  "version": "1.3.7",
+  "version": "0.0.1",
   "description": "GitHub action to automatically publish packages to npm",
   "author": "Pascal",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-publish-action",
-  "version": "0.0.1",
+  "version": "1.3.7",
   "description": "GitHub action to automatically publish packages to npm",
   "author": "Pascal",
   "license": "MIT",


### PR DESCRIPTION
PR for #20 issue

Add outputs context like [version-check](https://github.com/EndBug/version-check) repo.

### Outputs

- `changed`: either "true" or "false", indicates whether the version has changed.
- `version`: if the version has changed, it shows the version number (e.g. "1.0.2")
- `commit`: if the version has changed, it shows the sha of the commit where the change has been found.

To access these outputs, you need to access the context of the step you previously set up: you can find more info about steps contexts [here](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions#steps-context).  
If you set your step id to `check` you'll find the outputs at `steps.check.outputs.OUTPUT_NAME`: you can use these outputs as conditions for other steps.  
Here's an example:

```yaml
- name: Publish if version has been updated
  id: check
  uses: pascalgn/npm-publish-action@f6302932be3d13d292168d31a9ea193c717567ff
              # This is tagged version v1.3.7, but do not use version tags
              # https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

- name: Log when changed
  if: steps.check.outputs.changed == 'true'
  run: 'echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }}"'

- name: Log when unchanged
  if: steps.check.outputs.changed == 'false'
  run: 'echo "No version change :/"'
```