### PR TITLE
Replace deprecated set-ouput command

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
 const process = require("process");
 const { join } = require("path");
 const { spawn } = require("child_process");
-const { readFile } = require("fs");
+const { readFile, appendFileSync } = require("fs");
+const { EOL } = require("os");
 
 async function main() {
   const dir =
@@ -165,8 +166,8 @@ async function publishPackage(dir, config, version) {
 }
 
 function setOutput(name, value = "") {
-  const out = `name=${encodeURIComponent(name)}::${encodeURIComponent(value)}`;
-  console.log(`::set-output ${out}`);
+  const output = process.env['GITHUB_OUTPUT']
+  appendFileSync(output, `${key}=${value}${EOL}`)
 }
 
 function run(cwd, command, ...args) {


### PR DESCRIPTION
## Problem
I was getting these warnings in my pipeline because the `set-output` command is now deprecated.
![Screenshot 2023-11-24 104213](https://github.com/pascalgn/npm-publish-action/assets/5310778/9303e6eb-1c7c-4f73-b282-80e9b9df508c)

## Solution
Write to GitHub environment file instead of using the deprecated `set-output` command.

Following recommendations from https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

